### PR TITLE
fix: program exits with status 1, casue by 'wsl --exec netstat -tunlp…

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,8 @@ func main() {
 		// get all tcp ports in linux now
 		linuxPorts, err := service.GetLinuxHostPorts()
 		if err != nil {
-			log.Fatal(err)
+			log.Printf("GetLinuxHostPorts error: %s, retrying", err)
+			continue // Skipping current loop is Necessary. Otherwise, running port will be stopped.
 		}
 		// change proxy port by config "predefined"
 		for i, p := range linuxPorts {


### PR DESCRIPTION
"wsl --exec netstat -tunlp" may returns nothing, which cause program to exit with status 1.

Program automatically exits with status 1.
![exit](https://user-images.githubusercontent.com/53225269/185871712-30f56e14-f398-47f8-b2ad-e1228cf16828.png)

The first "wsl --exec netstat -tunlp" returns nothing, as shown below.
![netstat](https://user-images.githubusercontent.com/53225269/185871779-3ef779ed-990f-4c34-88a6-b33229e1d426.png)

My windows system's info：
Windows Server 2022 Standard
21H2
20348.740
